### PR TITLE
bump cluster version to 1.28 in e2e scripts

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@  --skip-istio-addon
+initialize "$@" --skip-istio-addon --cluster-version=1.28
 
 CERTIFICATE_CLASS="cert-manager.certificate.networking.knative.dev"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize "$@" --skip-istio-addon --cluster-version=1.28
+initialize "$@" --cluster-version=1.28
 
 CERTIFICATE_CLASS="cert-manager.certificate.networking.knative.dev"
 


### PR DESCRIPTION
## Changes

- specify cluster version to 1.28 in e2e test scripts

Fixes #669 